### PR TITLE
Move debug symbols to dbg package

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cpptango-green.svg)](https://anaconda.org/conda-forge/cpptango) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cpptango.svg)](https://anaconda.org/conda-forge/cpptango) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cpptango.svg)](https://anaconda.org/conda-forge/cpptango) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cpptango.svg)](https://anaconda.org/conda-forge/cpptango) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-cpptango--dbg-green.svg)](https://anaconda.org/conda-forge/cpptango-dbg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cpptango-dbg.svg)](https://anaconda.org/conda-forge/cpptango-dbg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cpptango-dbg.svg)](https://anaconda.org/conda-forge/cpptango-dbg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cpptango-dbg.svg)](https://anaconda.org/conda-forge/cpptango-dbg) |
 
 Installing cpptango
 ===================
@@ -65,10 +66,10 @@ Installing `cpptango` from the `conda-forge` channel can be achieved by adding `
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `cpptango` can be installed with:
+Once the `conda-forge` channel has been enabled, `cpptango, cpptango-dbg` can be installed with:
 
 ```
-conda install cpptango
+conda install cpptango cpptango-dbg
 ```
 
 It is possible to list all of the versions of `cpptango` available on your platform with:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,3 +14,9 @@ cmake -DCMAKE_BUILD_TYPE=Debug \
 
 make -j $CPU_COUNT
 make install
+
+# Separate debugging symbols
+${OBJCOPY} --only-keep-debug ${PREFIX}/lib/libtango.so.${PKG_VERSION} ${PREFIX}/lib/libtango.so.${PKG_VERSION}.dbg
+chmod 664 ${PREFIX}/lib/libtango.so.${PKG_VERSION}.dbg
+${OBJCOPY} --strip-debug ${PREFIX}/lib/libtango.so.${PKG_VERSION}
+${OBJCOPY} --add-gnu-debuglink=${PREFIX}/lib/libtango.so.${PKG_VERSION}.dbg ${PREFIX}/lib/libtango.so.${PKG_VERSION}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,10 @@ source:
 build:
   number: 2
   skip: true  # [not linux]
+  # Prevent libtango.so.{{ version }}.dbg to be modified
+  # Will raise CRC mismatch otherwise!
+  binary_relocation:
+    - lib/libtango.so.{{ version }}
   run_exports:
     - {{ pin_subpackage('cpptango', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 50828ae9f523c8b2eeb546b38138b0d0882fcd3050e952d93a66a594ed178e72
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not linux]
   # Prevent libtango.so.{{ version }}.dbg to be modified
   # Will raise CRC mismatch otherwise!

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 2
   skip: true  # [not linux]
-  run_exports :
+  run_exports:
     - {{ pin_subpackage('cpptango', max_pin='x.x') }}
 
 requirements:
@@ -37,6 +37,25 @@ test:
     - test -f ${PREFIX}/lib/libtango${SHLIB_EXT}
     - test -f ${PREFIX}/lib/pkgconfig/tango.pc
     - test -f ${PREFIX}/include/tango/tango.h
+
+outputs:
+  - name: cpptango
+    files:
+      - lib/libtango.so
+      - lib/libtango.so.9
+      - lib/libtango.so.{{ version }}
+      - lib/pkgconfig/tango.pc
+      - include/tango
+
+  - name: cpptango-dbg
+    requirements:
+      run:
+        - {{ pin_subpackage('cpptango', exact=True) }}
+    files:
+      - lib/libtango.so.{{ version }}.dbg
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libtango${SHLIB_EXT}.${PKG_VERSION}.dbg
 
 about:
   home: https://www.tango-controls.org


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

This is a proposal to move debug symbols to a separate package: `cpptango-dbg`
I use `objcopy` to extract the debug symbols to a separate file. By default, installing `cpptango` won't install the debug symbols. This reduces the size of the package. If people want to debug, they can install as well `cpptango-dbg` to get the debug symbols.
