### PR TITLE
Fix windows build

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -35,7 +35,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 

--- a/README.md
+++ b/README.md
@@ -38,28 +38,28 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11614&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11614&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11614&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11614&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cpptango-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://gitlab.com/tango-controls/{{ name }}/-/archive/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6a6368564f7762881a0c5b4a2023c9af1a2872aa648d94a679b4e8789283a409
+  # url: https://gitlab.com/tango-controls/{{ name }}/-/archive/{{ version }}/{{ name }}-{{ version }}.tar.gz
+  url: https://gitlab.com/tango-controls/cppTango/-/archive/9.4.0.windows0/cppTango-9.4.0.windows0.tar.gz
+  sha256: 919daf8da36e3860150226c449d793f84cfe832ca0f133b9359bf2090312ac91
   patches:
     - windows-lib-names.patch  # [win]
+    - windows-external-symbol.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   # Prevent libtango.so.{{ version }}.dbg to be modified
   # Will raise CRC mismatch otherwise!
   binary_relocation:                 # [linux]

--- a/recipe/windows-external-symbol.patch
+++ b/recipe/windows-external-symbol.patch
@@ -1,0 +1,13 @@
+diff --git a/cppapi/include/tango/client/ApiUtil.h b/cppapi/include/tango/client/ApiUtil.h
+index 938ef7a2..5d136e9c 100644
+--- a/cppapi/include/tango/client/ApiUtil.h
++++ b/cppapi/include/tango/client/ApiUtil.h
+@@ -236,7 +236,7 @@ private:
+     };
+ 
+ 	TANGO_IMP static ApiUtil 	*_instance;
+-	static omni_mutex			inst_mutex;
++	TANGO_IMP static omni_mutex			inst_mutex;
+ 	bool						exit_lock_installed;
+ 	bool						reset_already_executed_flag;
+ 

--- a/recipe/windows-lib-names.patch
+++ b/recipe/windows-lib-names.patch
@@ -1,5 +1,5 @@
 diff --git a/configure/CMakeLists.txt b/configure/CMakeLists.txt
-index 9416f5bf..aecedcb4 100644
+index 130c1943..bb479dd1 100644
 --- a/configure/CMakeLists.txt
 +++ b/configure/CMakeLists.txt
 @@ -79,15 +79,8 @@ if(TANGO_ZMQ_BASE)
@@ -20,7 +20,7 @@ index 9416f5bf..aecedcb4 100644
      else()
          set(ZMQ_PKG_LIBRARIES "-lzmq")
          link_directories(${TANGO_ZMQ_BASE}/lib)
-@@ -126,8 +119,8 @@ if(PTHREAD_WIN)
+@@ -130,8 +123,8 @@ if(PTHREAD_WIN)
          set(PTHREAD_WIN_PKG_LIBRARIES_DYN "pthreadVC2d.lib")
          set(PTHREAD_WIN_PKG_LIBRARIES_STA "pthreadVC2-sd.lib")
      else()


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

pytango fails to compile with cpptango 9.4.0 on Windows due to a missing symbol:

```
2022-11-08T08:20:01.2638762Z api_util.cpp.obj : error LNK2019: unresolved external symbol "private: static class omni_mutex Tango::ApiUtil::inst_mutex" (?inst_mutex@ApiUtil@Tango@@0Vomni_mutex@@A) referenced in function "public: static class Tango::ApiUtil * __cdecl Tango::ApiUtil::instance(void)" (?instance@ApiUtil@Tango@@SAPEAV12@XZ) 2022-11-08T08:20:01.2641347Z _tango.pyd : fatal error LNK1120: 1 unresolved externals
```

- add patch to fix this issue
- use 9.4.0.windows0 tag as source as this is the official version (there should be no impact on the conda package compared to 9.4.0 tag)

See https://gitlab.com/tango-controls/cppTango/-/issues/1011
